### PR TITLE
Make supported types in dialect yaml files as a map

### DIFF
--- a/bft/dialects/types.py
+++ b/bft/dialects/types.py
@@ -83,7 +83,7 @@ class DialectFile(NamedTuple):
     scalar_functions: List[DialectFunction]
     aggregate_functions: List[DialectFunction]
     uri_to_func_prefix: Dict[str, str]
-    supported_types: List[str]
+    supported_types: Dict[str, str]
 
 
 class SqlMapping(NamedTuple):

--- a/bft/dialects/types.py
+++ b/bft/dialects/types.py
@@ -83,7 +83,7 @@ class DialectFile(NamedTuple):
     scalar_functions: List[DialectFunction]
     aggregate_functions: List[DialectFunction]
     uri_to_func_prefix: Dict[str, str]
-    supported_types: Dict[str, str]
+    supported_types: Dict[str, Dict]
 
 
 class SqlMapping(NamedTuple):

--- a/dialects/cudf.yaml
+++ b/dialects/cudf.yaml
@@ -26,16 +26,26 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i8: int8
-  i16: int16
-  i32: int32
-  i64: int64
-  fp32: float32
-  fp64: float64
-  bool: bool
-  str: string
-  ts: datetime64[s]
-  date: datetime64[s]
+  i8:
+    df_type_name: int8
+  i16:
+    df_type_name: int16
+  i32:
+    df_type_name: int32
+  i64:
+    df_type_name: int64
+  fp32:
+    df_type_name: float32
+  fp64:
+    df_type_name: float64
+  bool:
+    df_type_name: bool
+  str:
+    df_type_name: string
+  ts:
+    df_type_name: datetime64[s]
+  date:
+    df_type_name: datetime64[s]
 scalar_functions:
 - name: arithmetic.add
   local_name: add

--- a/dialects/cudf.yaml
+++ b/dialects/cudf.yaml
@@ -26,16 +26,16 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i8
-  - i16
-  - i32
-  - i64
-  - fp32
-  - fp64
-  - bool
-  - str
-  - ts
-  - date
+  i8: int8
+  i16: int16
+  i32: int32
+  i64: int64
+  fp32: float32
+  fp64: float64
+  bool: bool
+  str: string
+  ts: datetime64[s]
+  date: datetime64[s]
 scalar_functions:
 - name: arithmetic.add
   local_name: add

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -26,18 +26,30 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i8: int8
-  i16: int16
-  i32: int32
-  i64: int64
-  fp32: float32
-  fp64: float64
-  bool: bool_
-  str: string
-  date: timestamp
-  time: timestamp
-  ts: timestamp
-  tstz: timestamp
+  i8:
+    sql_type_name: int8
+  i16:
+    sql_type_name: int16
+  i32:
+    sql_type_name: int32
+  i64:
+    sql_type_name: int64
+  fp32:
+    sql_type_name: float32
+  fp64:
+    sql_type_name: float64
+  bool:
+    sql_type_name: bool_
+  str:
+    sql_type_name: string
+  date:
+    sql_type_name: timestamp
+  time:
+    sql_type_name: timestamp
+  ts:
+    sql_type_name: timestamp
+  tstz:
+    sql_type_name: timestamp
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -26,19 +26,18 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i8
-  - i16
-  - i32
-  - i64
-  - fp32
-  - fp64
-  - bool
-  - str
-  - date
-  - time
-  - ts
-  - tstz
-  - interval
+  i8: int8
+  i16: int16
+  i32: int32
+  i64: int64
+  fp32: float32
+  fp64: float64
+  bool: bool_
+  str: string
+  date: timestamp
+  time: timestamp
+  ts: timestamp
+  tstz: timestamp
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -26,20 +26,34 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i8: TINYINT,
-  i16: SMALLINT
-  i32: INTEGER
-  i64: BIGINT
-  fp32: REAL
-  fp64: DOUBLE
-  bool: BOOLEAN
-  str: VARCHAR
-  date: DATE
-  time: TIME
-  ts: TIMESTAMP
-  tstz: TIMESTAMPTZ
-  interval: INTERVAL
-  decimal: DECIMAL
+  i8:
+    sql_type_name: TINYINT,
+  i16:
+    sql_type_name: SMALLINT
+  i32:
+    sql_type_name: INTEGER
+  i64:
+    sql_type_name: BIGINT
+  fp32:
+    sql_type_name: REAL
+  fp64:
+    sql_type_name: DOUBLE
+  bool:
+    sql_type_name: BOOLEAN
+  str:
+    sql_type_name: VARCHAR
+  date:
+    sql_type_name: DATE
+  time:
+    sql_type_name: TIME
+  ts:
+    sql_type_name: TIMESTAMP
+  tstz:
+    sql_type_name: TIMESTAMPTZ
+  interval:
+    sql_type_name: INTERVAL
+  decimal:
+    sql_type_name: DECIMAL
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -27,33 +27,33 @@ dependencies:
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
   i8:
-    sql_type_name: TINYINT,
+    sql_type_name: tinyint
   i16:
-    sql_type_name: SMALLINT
+    sql_type_name: smallint
   i32:
-    sql_type_name: INTEGER
+    sql_type_name: integer
   i64:
-    sql_type_name: BIGINT
+    sql_type_name: bigint
   fp32:
-    sql_type_name: REAL
+    sql_type_name: real
   fp64:
-    sql_type_name: DOUBLE
+    sql_type_name: double
   bool:
-    sql_type_name: BOOLEAN
+    sql_type_name: boolean
   str:
-    sql_type_name: VARCHAR
+    sql_type_name: varchar
   date:
-    sql_type_name: DATE
+    sql_type_name: date
   time:
-    sql_type_name: TIME
+    sql_type_name: time
   ts:
-    sql_type_name: TIMESTAMP
+    sql_type_name: timestamp
   tstz:
-    sql_type_name: TIMESTAMPTZ
+    sql_type_name: timestamptz
   interval:
-    sql_type_name: INTERVAL
+    sql_type_name: interval
   decimal:
-    sql_type_name: DECIMAL
+    sql_type_name: decimal
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -26,20 +26,20 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i8
-  - i16
-  - i32
-  - i64
-  - fp32
-  - fp64
-  - bool
-  - str
-  - date
-  - time
-  - ts
-  - tstz
-  - interval
-  - dec
+  i8: TINYINT,
+  i16: SMALLINT
+  i32: INTEGER
+  i64: BIGINT
+  fp32: REAL
+  fp64: DOUBLE
+  bool: BOOLEAN
+  str: VARCHAR
+  date: DATE
+  time: TIME
+  ts: TIMESTAMP
+  tstz: TIMESTAMPTZ
+  interval: INTERVAL
+  decimal: DECIMAL
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -26,18 +26,18 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i16
-  - i32
-  - i64
-  - fp32
-  - fp64
-  - bool
-  - str
-  - date
-  - time
-  - ts
-  - tstz
-  - interval
+  i16: smallint
+  i32: integer
+  i64: bigint
+  fp32: float4
+  fp64: float8
+  bool: boolean
+  str: text
+  date: date
+  time: time
+  ts: timestamp
+  tstz: timestamptz
+  interval: interval
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -26,18 +26,30 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i16: smallint
-  i32: integer
-  i64: bigint
-  fp32: float4
-  fp64: float8
-  bool: boolean
-  str: text
-  date: date
-  time: time
-  ts: timestamp
-  tstz: timestamptz
-  interval: interval
+  i16:
+    sql_type_name: smallint
+  i32:
+    sql_type_name: integer
+  i64:
+    sql_type_name: bigint
+  fp32:
+    sql_type_name: float4
+  fp64:
+    sql_type_name: float8
+  bool:
+    sql_type_name: boolean
+  str:
+    sql_type_name: text
+  date:
+    sql_type_name: date
+  time:
+    sql_type_name: time
+  ts:
+    sql_type_name: timestamp
+  tstz:
+    sql_type_name: timestamptz
+  interval:
+    sql_type_name: interval
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -27,24 +27,24 @@ dependencies:
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
   fp64:
-    sql_type_name: FLOAT
+    sql_type_name: float
   bool:
-    sql_type_name: BOOLEAN
+    sql_type_name: boolean
   str:
-    sql_type_name: VARCHAR
+    sql_type_name: varchar
   date:
-    sql_type_name: DATE
+    sql_type_name: date
   time:
-    sql_type_name: TIME
+    sql_type_name: time
   ts:
-    sql_type_name: TIMESTAMP
+    sql_type_name: timestamp
   tstz:
-    sql_type_name: TIMESTAMPTZ
+    sql_type_name: timestamptz
   interval:
-    sql_type_name: INTERVAL
+    sql_type_name: interval
     supported_as_column: false
   dec:
-    sql_type_name: NUMERIC
+    sql_type_name: numeric
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -26,15 +26,24 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  fp64: FLOAT
-  bool: BOOLEAN
-  str: VARCHAR
-  date: DATE
-  time: TIME
-  ts: TIMESTAMP
-  tstz: TIMESTAMPTZ
-  interval: INTERVAL
-  dec: NUMERIC
+  fp64:
+    sql_type_name: FLOAT
+  bool:
+    sql_type_name: BOOLEAN
+  str:
+    sql_type_name: VARCHAR
+  date:
+    sql_type_name: DATE
+  time:
+    sql_type_name: TIME
+  ts:
+    sql_type_name: TIMESTAMP
+  tstz:
+    sql_type_name: TIMESTAMPTZ
+  interval:
+    sql_type_name: INTERVAL
+  dec:
+    sql_type_name: NUMERIC
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -26,15 +26,15 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - fp64
-  - bool
-  - str
-  - date
-  - time
-  - ts
-  - tsz
-  - interval
-  - dec
+  fp64: FLOAT
+  bool: BOOLEAN
+  str: VARCHAR
+  date: DATE
+  time: TIME
+  ts: TIMESTAMP
+  tstz: TIMESTAMPTZ
+  interval: INTERVAL
+  dec: NUMERIC
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -42,6 +42,7 @@ supported_types:
     sql_type_name: TIMESTAMPTZ
   interval:
     sql_type_name: INTERVAL
+    supported_as_column: false
   dec:
     sql_type_name: NUMERIC
 scalar_functions:

--- a/dialects/sqlite.yaml
+++ b/dialects/sqlite.yaml
@@ -26,14 +26,14 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i8
-  - i16
-  - i32
-  - i64
-  - fp32
-  - fp64
-  - bool
-  - str
+  i8: TINYINT
+  i16: SMALLINT
+  i32: INT
+  i64: HUGEINT
+  fp32: REAL
+  fp64: REAL
+  bool: BOOLEAN
+  str: TEXT
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/sqlite.yaml
+++ b/dialects/sqlite.yaml
@@ -26,14 +26,22 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i8: TINYINT
-  i16: SMALLINT
-  i32: INT
-  i64: HUGEINT
-  fp32: REAL
-  fp64: REAL
-  bool: BOOLEAN
-  str: TEXT
+  i8:
+    sql_type_name: TINYINT
+  i16:
+    sql_type_name: SMALLINT
+  i32:
+    sql_type_name: INT
+  i64:
+    sql_type_name: HUGEINT
+  fp32:
+    sql_type_name: REAL
+  fp64:
+    sql_type_name: REAL
+  bool:
+    sql_type_name: BOOLEAN
+  str:
+    sql_type_name: TEXT
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/sqlite.yaml
+++ b/dialects/sqlite.yaml
@@ -27,21 +27,21 @@ dependencies:
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
   i8:
-    sql_type_name: TINYINT
+    sql_type_name: tinyint
   i16:
-    sql_type_name: SMALLINT
+    sql_type_name: smallint
   i32:
-    sql_type_name: INT
+    sql_type_name: int
   i64:
-    sql_type_name: HUGEINT
+    sql_type_name: hugeint
   fp32:
-    sql_type_name: REAL
+    sql_type_name: real
   fp64:
-    sql_type_name: REAL
+    sql_type_name: real
   bool:
-    sql_type_name: BOOLEAN
+    sql_type_name: boolean
   str:
-    sql_type_name: TEXT
+    sql_type_name: text
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/velox_presto.yaml
+++ b/dialects/velox_presto.yaml
@@ -26,10 +26,14 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  i64: i64
-  fp64: fp64
-  bool: boolean
-  str: string
+  i64:
+    sql_type_name: i64
+  fp64:
+    sql_type_name: fp64
+  bool:
+    sql_type_name: boolean
+  str:
+    sql_type_name: string
 scalar_functions:
 - name: arithmetic.add
   local_name: +

--- a/dialects/velox_presto.yaml
+++ b/dialects/velox_presto.yaml
@@ -26,10 +26,10 @@ dependencies:
   string: 
     https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_string.yaml
 supported_types:
-  - i64
-  - fp64
-  - bool
-  - str
+  i64: i64
+  fp64: fp64
+  bool: boolean
+  str: string
 scalar_functions:
 - name: arithmetic.add
   local_name: +


### PR DESCRIPTION
This change is needed to build a [FunctionRegistry](https://github.com/substrait-io/substrait-go/issues/28) in substrait-go [PR](https://github.com/substrait-io/substrait-go/pull/32)
