### PR TITLE
Add test cases for arithmetic decimal function "sqrt" and "factorial"

### DIFF
--- a/bft/cases/parser.py
+++ b/bft/cases/parser.py
@@ -34,6 +34,8 @@ class CaseFileVisitor(BaseYamlVisitor[CaseFile]):
                     return float("inf")
                 elif value.lower().startswith("-inf"):
                     return float("-inf")
+                elif value.lower().startswith("1e"):
+                    return float(value.lower())
                 elif value.lower().startswith("nan"):
                     return math.nan
                 else:

--- a/cases/arithmetic_decimal/factorial_decimal.yaml
+++ b/cases/arithmetic_decimal/factorial_decimal.yaml
@@ -1,0 +1,59 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_arithmetic_decimal.yaml
+function: factorial
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 0
+        type: decimal<1,0>
+    result:
+      value: 1
+      type: decimal<38,0>
+  - group: basic
+    args:
+      - value: 1
+        type: decimal<1,0>
+    result:
+      value: 1
+      type: decimal<38,0>
+  - group: basic
+    args:
+      - value: 20
+        type: decimal<2,0>
+    result:
+      value: 2432902008176640000
+      type: decimal<38,0>
+  - group:
+      id: overflow
+      description: Examples demonstrating overflow behavior
+    args:
+      - value: 34
+        type: decimal<2,0>
+    result:
+      special: error
+  - group:
+      id: negative_value
+      description: Examples demonstrating behavior on negative value
+    args:
+      - value: -1
+        type: decimal<1,0>
+    result:
+      special: error
+  - group:
+      id: null_values
+      description: test with null values
+    args:
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: decimal<38, 0>
+  - group: null_values
+    args:
+      - value: null
+        type: decimal<1, 0>
+    result:
+      value: null
+      type: decimal<38, 0>
+

--- a/cases/arithmetic_decimal/sqrt_decimal.yaml
+++ b/cases/arithmetic_decimal/sqrt_decimal.yaml
@@ -1,0 +1,112 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_arithmetic_decimal.yaml
+function: sqrt
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 25
+        type: decimal<2,0>
+    result:
+      value: 5
+      type: fp64
+  - group: basic
+    args:
+      - value: 0
+        type: decimal<1,0>
+    result:
+      value: 0
+      type: fp64
+  - group:
+      id: max_input
+      description: max allowed input returns correct result
+    args:
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38,0>
+    result:
+      value: 1e+19
+      type: fp64
+  - group:
+      id: real_number
+      description: real number as input
+    args:
+      - value: 6.25
+        type: decimal<3,2>
+    result:
+      value: 2.5
+      type: fp64
+  - group: real_number
+    args:
+      - value: 2.0000007152557373046875
+        type: decimal<23,22>
+    result:
+      value: 1.4142138152541635
+      type: fp64
+  - group:
+      id: verify_real_number
+      description: verify real number operation are different and doesn't behave as nearby int
+    args:
+      - value: 9
+        type: decimal<1,0>
+    result:
+      value: 3
+      type: fp64
+  - group: verify_real_number
+    args:
+      - value: 8.3
+        type: decimal<2,1>
+    result:
+      value: 2.8809720581775866
+      type: fp64
+  - group: verify_real_number
+    args:
+      - value: 8.5
+        type: decimal<2,1>
+    result:
+      value: 2.9154759474226504
+      type: fp64
+  - group: verify_real_number
+    args:
+      - value: 8.7
+        type: decimal<2,1>
+    result:
+      value: 2.949576240750525
+      type: fp64
+  - group: verify_real_number
+    args:
+      - value: 9.2
+        type: decimal<2,1>
+    result:
+      value: 3.03315017762062
+      type: fp64
+  - group:
+      id: negative_input
+      description: negative input returns error
+    args:
+      - value: -9223372036854775800
+        type: decimal<19,0>
+    result:
+      special: error
+  - group: negative_input
+    args:
+      - value: -2.5
+        type: decimal<2,1>
+    result:
+      special: error
+  - group:
+      id: null_values
+      description: test with null values
+    args:
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: fp64
+  - group: null_values
+    args:
+      - value: null
+        type: decimal<1, 0>
+    result:
+      value: null
+      type: fp64
+

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -116,12 +116,6 @@ scalar_functions:
   - i64_i64
   - fp32_fp32
   - fp64_fp64
-- name: arithmetic_decimal.power
-  local_name: pow
-  required_options:
-    complex_number_result: NAN
-  supported_kernels:
-  - dec_dec
 - name: arithmetic.sqrt
   local_name: sqrt
   required_options:
@@ -677,3 +671,13 @@ aggregate_functions:
   aggregate: true
   supported_kernels:
   - bool
+- name: arithmetic_decimal.power
+  local_name: pow
+  required_options:
+    complex_number_result: NAN
+  supported_kernels:
+  - dec_dec
+- name: arithmetic_decimal.sqrt
+  local_name: sqrt
+  supported_kernels:
+    - dec

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -59,13 +59,6 @@ scalar_functions:
     rounding: TIE_TO_EVEN
   supported_kernels:
   - fp64_fp64
-- name: arithmetic_decimal.power
-  local_name: pow
-  required_options:
-    overflow: ERROR
-    complex_number_result: ERROR
-  supported_kernels:
-  - dec_dec
 - name: arithmetic.sqrt
   local_name: sqrt
   required_options:
@@ -384,3 +377,18 @@ aggregate_functions:
   local_name: bitxor
   supported_kernels:
     - dec_dec
+- name: arithmetic_decimal.power
+  local_name: pow
+  required_options:
+    overflow: ERROR
+    complex_number_result: ERROR
+  supported_kernels:
+  - dec_dec
+- name: arithmetic_decimal.sqrt
+  local_name: sqrt
+  supported_kernels:
+    - dec
+- name: arithmetic_decimal.factorial
+  local_name: factorial
+  supported_kernels:
+    - dec


### PR DESCRIPTION
* duckdb doesn't support factorial on decimal type so it is not supported in duckdb dialect
* Currently I am focusing on Snowflake and Duckdb dialect so skipped other dialects for now.
* Updated Precision based on Substrait Spec ([here](https://github.com/substrait-io/substrait/blob/28025cbaa8dc3c65b736d8a68fa7070c465fb494/extensions/functions_arithmetic_decimal.yaml#L152-L168)) which is as follows:
Sqrt:
Input: DECIMAL<P, S> ==> Result fp64
Factorial:
Input: DECIMAL<P, S> ==> Result DECIMAL<38,0>