### PR TITLE
Fixed deprecated docker compose command in workflow and test error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,10 @@ jobs:
           submodules: recursive
 
       - name: Build
-        run: docker-compose -f ./ci/docker/postgres-compose.yaml build
+        run: docker compose -f ./ci/docker/postgres-compose.yaml build
 
       - name: Run
-        run: docker-compose -f ./ci/docker/postgres-compose.yaml run app
+        run: docker compose -f ./ci/docker/postgres-compose.yaml run app
   velox:
     name: Run tests with velox
     runs-on: ubuntu-latest
@@ -62,10 +62,10 @@ jobs:
         with:
           submodules: recursive
       - name: Build
-        run: docker-compose -f ./ci/docker/velox-compose.yaml build
+        run: docker compose -f ./ci/docker/velox-compose.yaml build
 
       - name: Run
-        run: docker-compose -f ./ci/docker/velox-compose.yaml run app
+        run: docker compose -f ./ci/docker/velox-compose.yaml run app
   site:
     name: Build site
     runs-on: ubuntu-latest

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -229,7 +229,7 @@ scalar_functions:
   local_name: factorial
   infix: false
   required_options:
-    overflow: SILENT
+    overflow: ERROR
   supported_kernels:
   - i32
   - i64


### PR DESCRIPTION
* docker-compose was deprecated ([reference](https://github.com/orgs/community/discussions/116610))
* datafusion factorial returns error on overflow. Fixed it too. It was causing github workflow to fail for datafusion job