### PR TITLE
Add test cases for bitwise and/or/xor for decimal type

### DIFF
--- a/cases/arithmetic_decimal/bitwise_and.yaml
+++ b/cases/arithmetic_decimal/bitwise_and.yaml
@@ -59,12 +59,12 @@ cases:
       type: decimal<10, 0>
   - group: basic
     args:
-      - value: 2147483647
+      - value: -2147483647
         type: decimal<10, 0>
       - value: 1234567
         type: decimal<7, 0>
     result:
-      value: 1234567
+      value: 1
       type: decimal<10, 0>
   - group: basic
     args:

--- a/cases/arithmetic_decimal/bitwise_and.yaml
+++ b/cases/arithmetic_decimal/bitwise_and.yaml
@@ -1,0 +1,121 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_arithmetic_decimal.yaml
+function: bitwise_and
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 0
+        type: decimal<1, 0>
+      - value: 1
+        type: decimal<1, 0>
+    result:
+      value: 0
+      type: decimal<1, 0>
+  - group: basic
+    args:
+      - value: 127
+        type: decimal<3, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 127
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: -127
+        type: decimal<3, 0>
+      - value: -10
+        type: decimal<2, 0>
+    result:
+      value: -128
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: 31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: 4
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: -31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: 896
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 1234567
+        type: decimal<7, 0>
+    result:
+      value: 1234567
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 1234567
+        type: decimal<7, 0>
+    result:
+      value: 1234567
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 127
+      type: decimal<19, 0>
+  - group: basic
+    args:
+      - value: -9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 1
+      type: decimal<19, 0>
+  - group:
+      id: max_values
+      description: test with max values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      value: 99999999999999999999999999999999999999
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 0s
+      - value: 00000000000000000000000000000000000000
+        type: decimal<38, 0>
+    result:
+      value: 0
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      value: -99999999999999999999999999999999999999
+      type: decimal<38, 0>

--- a/cases/arithmetic_decimal/bitwise_or.yaml
+++ b/cases/arithmetic_decimal/bitwise_or.yaml
@@ -59,12 +59,12 @@ cases:
       type: decimal<10, 0>
   - group: basic
     args:
-      - value: 2147483647
+      - value: -2147483647
         type: decimal<10, 0>
       - value: 123456789
         type: decimal<9, 0>
     result:
-      value: 2147483647
+      value: -2024026859
       type: decimal<10, 0>
   - group: basic
     args:

--- a/cases/arithmetic_decimal/bitwise_or.yaml
+++ b/cases/arithmetic_decimal/bitwise_or.yaml
@@ -1,0 +1,143 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_arithmetic_decimal.yaml
+function: bitwise_or
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 0
+        type: decimal<1, 0>
+      - value: 1
+        type: decimal<1, 0>
+    result:
+      value: 1
+      type: decimal<1, 0>
+  - group: basic
+    args:
+      - value: 127
+        type: decimal<3, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 127
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: -127
+        type: decimal<3, 0>
+      - value: -10
+        type: decimal<2, 0>
+    result:
+      value: -9
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: 31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: 32662
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: -31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: -31762
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 123456789
+        type: decimal<9, 0>
+    result:
+      value: 2147483647
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 123456789
+        type: decimal<9, 0>
+    result:
+      value: 2147483647
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 9223372036854775807
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: -9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: -9223372036854775681
+      type: decimal<19, 0>
+  - group:
+      id: max_values
+      description: test with max values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      value: 99999999999999999999999999999999999999
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 0s
+      - value: 00000000000000000000000000000000000000
+        type: decimal<38, 0>
+    result:
+      # 38 9s
+      value: 99999999999999999999999999999999999999
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      # negative 38 9s
+      value: -99999999999999999999999999999999999999
+      type: decimal<38, 0>
+  - group:
+      id: null_values
+      description: test with null values
+    args:
+      - value: null
+        type: decimal<1, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: null
+      type: decimal<3, 0>
+  - group: null_values
+    args:
+      - value: null
+        type: decimal<1, 0>
+      - value: null
+        type: decimal<1, 0>
+    result:
+      value: null
+      type: decimal<1, 0>

--- a/cases/arithmetic_decimal/bitwise_xor.yaml
+++ b/cases/arithmetic_decimal/bitwise_xor.yaml
@@ -1,0 +1,142 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_arithmetic_decimal.yaml
+function: bitwise_xor
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 0
+        type: decimal<1, 0>
+      - value: 1
+        type: decimal<1, 0>
+    result:
+      value: 1
+      type: decimal<1, 0>
+  - group: basic
+    args:
+      - value: 127
+        type: decimal<3, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 0
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: -127
+        type: decimal<3, 0>
+      - value: -10
+        type: decimal<2, 0>
+    result:
+      value: 119
+      type: decimal<3, 0>
+  - group: basic
+    args:
+      - value: 31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: 32658
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: -31766
+        type: decimal<5, 0>
+      - value: 900
+        type: decimal<3, 0>
+    result:
+      value: -32658
+      type: decimal<5, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 123456789
+        type: decimal<9, 0>
+    result:
+      value: 2024026858
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 2147483647
+        type: decimal<10, 0>
+      - value: 123456789
+        type: decimal<9, 0>
+    result:
+      value: 2024026858
+      type: decimal<10, 0>
+  - group: basic
+    args:
+      - value: 9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: 9223372036854775680
+      type: decimal<19, 0>
+  - group: basic
+    args:
+      - value: -9223372036854775807
+        type: decimal<19, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: -9223372036854775682
+      type: decimal<19, 0>
+  - group:
+      id: max_values
+      description: test with max values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      value: 0
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # 38 9s
+      - value: 99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # 38 0s
+      - value: 00000000000000000000000000000000000000
+        type: decimal<38, 0>
+    result:
+      # 38 9s
+      value: 99999999999999999999999999999999999999
+      type: decimal<38, 0>
+  - group: max_values
+    args:
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+      # negative 38 9s
+      - value: -99999999999999999999999999999999999999
+        type: decimal<38, 0>
+    result:
+      value: 0
+      type: decimal<38, 0>
+  - group:
+      id: null_values
+      description: test with null values
+    args:
+      - value: null
+        type: decimal<1, 0>
+      - value: 127
+        type: decimal<3, 0>
+    result:
+      value: null
+      type: decimal<3, 0>
+  - group: null_values
+    args:
+      - value: null
+        type: decimal<1, 0>
+      - value: null
+        type: decimal<1, 0>
+    result:
+      value: null
+      type: decimal<1, 0>

--- a/cases/arithmetic_decimal/bitwise_xor.yaml
+++ b/cases/arithmetic_decimal/bitwise_xor.yaml
@@ -59,12 +59,12 @@ cases:
       type: decimal<10, 0>
   - group: basic
     args:
-      - value: 2147483647
+      - value: -2147483647
         type: decimal<10, 0>
       - value: 123456789
         type: decimal<9, 0>
     result:
-      value: 2024026858
+      value: -2024026860
       type: decimal<10, 0>
   - group: basic
     args:

--- a/cases/arithmetic_decimal/power_decimal.yaml
+++ b/cases/arithmetic_decimal/power_decimal.yaml
@@ -92,3 +92,23 @@ cases:
       complex_number_result: ERROR
     result:
       special: error
+  - group:
+      id: null_values
+      description: test with null values
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: 127
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: decimal<38, 0>
+  - group: null_values
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: decimal<38, 0>

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -360,3 +360,15 @@ aggregate_functions:
   aggregate: true
   supported_kernels:
   - bool
+- name: arithmetic_decimal.bitwise_and
+  local_name: bitand
+  supported_kernels:
+    - dec_dec
+- name: arithmetic_decimal.bitwise_or
+  local_name: bitor
+  supported_kernels:
+    - dec_dec
+- name: arithmetic_decimal.bitwise_xor
+  local_name: bitxor
+  supported_kernels:
+    - dec_dec


### PR DESCRIPTION
* duckdb doesn't support bitwise and/or/xor for decimal type so not supported in duckdb dialect
* Set scale/precision based on Substrait spec ([here](https://github.com/substrait-io/substrait/blob/28025cbaa8dc3c65b736d8a68fa7070c465fb494/extensions/functions_arithmetic_decimal.yaml#L113-L151)) which is as follows for bitwise_and/or/xor :
Input: (<P1, 0>, <P2, 0>) ==> Result: <max(P1, P2), 0>)