### PR TITLE
fix validation logic for date datatype in duckdb and postgres

### DIFF
--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -7,6 +7,7 @@ import psycopg
 from bft.cases.runner import SqlCaseResult, SqlCaseRunner
 from bft.cases.types import Case
 from bft.dialects.types import SqlMapping
+from bft.utils.utils import datetype_value_equal
 
 type_map = {
     "i16": "smallint",
@@ -152,7 +153,9 @@ class PostgresRunner(SqlCaseRunner):
             else:
                 if result == case.result.value:
                     return SqlCaseResult.success()
-                elif is_datetype(result) and str(result) == case.result.value:
+                elif is_datetype(result) and datetype_value_equal(
+                    result, case.result.value
+                ):
                     return SqlCaseResult.success()
                 else:
                     return SqlCaseResult.mismatch(str(result))

--- a/bft/utils/utils.py
+++ b/bft/utils/utils.py
@@ -1,4 +1,5 @@
 from typing import Dict
+import datetime
 
 
 def type_to_dialect_type(type: str, type_map: Dict[str, str])->str:
@@ -24,3 +25,24 @@ def type_to_dialect_type(type: str, type_map: Dict[str, str])->str:
         return type_val
     # transform parameterized type name to have dialect type
     return type.replace(type_to_check, type_val).replace("<", "(").replace(">", ")")
+
+def has_only_date(value: datetime.datetime):
+    if (
+        value.hour == 0
+        and value.minute == 0
+        and value.second == 0
+        and value.microsecond == 0
+    ):
+        return True
+    return False
+
+def datetype_value_equal(result, case_result):
+    if str(result) == case_result:
+        return True
+    if (
+        isinstance(result, datetime.datetime)
+        and has_only_date(result)
+        and str(result.date()) == case_result
+    ):
+        return True
+    return False


### PR DESCRIPTION
This fix is pre-requisite to using test cases from substrait directly.

substrait testcases have examples which can only contain the date part but the python client returns a datetime object.

Converting these to strings and comparing is not quite right. e.g., '2024-03-01' == '2024-03-01:00:00:00' will fail if we do string compare.

The fix is to not compare the empty fields hrs, mins, secs, etc if we only contain the date part